### PR TITLE
fix missing crypto import, extract shared utils, close issues #27 #38…

### DIFF
--- a/apps/web/MIGRATION_STEPS.txt
+++ b/apps/web/MIGRATION_STEPS.txt
@@ -1,0 +1,28 @@
+STEPS TO ACTIVATE MATCH PERSISTENCE (#38)
+==========================================
+
+The code for crash/disconnect recovery is written but needs a DB migration to work.
+Run these commands once your database is running:
+
+1. cd apps/web
+
+2. npx prisma migrate dev --name add-match-persistence
+   (Creates the Match table in Postgres)
+
+3. npx prisma generate
+   (Regenerates the Prisma client with the new Match model — removes the `(prisma as any)` TS workarounds)
+
+4. After step 3, clean up the two `(prisma as any)` casts in:
+   apps/web/lib/game-server/match.ts
+   - saveMatchState() around line 250 — change `(prisma as any).match.upsert` to `prisma.match.upsert`
+   - getMatch() around line 262 — change `(prisma as any).match.findUnique` to `prisma.match.findUnique`
+   - recordFinishedMatchStats() around line 540 — change `(prisma as any).match.delete` to `prisma.match.delete`
+
+The Match model added to schema.prisma:
+  model Match {
+    id        String   @id
+    state     Json
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+    expiresAt DateTime
+  }

--- a/apps/web/app/api/match/[id]/action/route.ts
+++ b/apps/web/app/api/match/[id]/action/route.ts
@@ -1,6 +1,7 @@
-import { NextResponse } from "next/server";
-import { applyAction, resolvePlayerByToken } from "@/lib/game-server/match";
+import { NextRequest, NextResponse } from "next/server";
+import { applyAction, resolvePlayerByToken, getMatch } from "@/lib/game-server/match";
 import { toPublicState, ActionType } from "@/lib/game-server/types";
+import { verifyRequestAuth } from "@/lib/auth-session";
 
 const VALID_ACTIONS: ActionType[] = [
   "DRAW_CARD",
@@ -26,7 +27,7 @@ const CARD_ACTIONS: ActionType[] = [
 ];
 
 export async function POST(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -48,6 +49,19 @@ export async function POST(
     const playerId = await resolvePlayerByToken(id, matchToken);
     if (!playerId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // If this player slot has a Firebase UID stored, cross-validate that the
+    // request carries a matching Firebase session — prevents token misuse if leaked.
+    const matchState = await getMatch(id);
+    if (matchState) {
+      const storedUid = playerId === "p1" ? matchState.p1FirebaseUid : matchState.p2FirebaseUid;
+      if (storedUid !== null) {
+        const session = await verifyRequestAuth(request);
+        if (!session || session.uid !== storedUid) {
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
+      }
     }
 
     const body = await request.json();

--- a/apps/web/app/api/match/create/route.ts
+++ b/apps/web/app/api/match/create/route.ts
@@ -16,19 +16,21 @@ export async function POST(request: NextRequest) {
 
     // When a deckId is provided, authenticate to verify deck ownership.
     let userId: string | undefined;
+    let firebaseUid: string | undefined;
     if (deckId) {
       const auth = await getAuthenticatedUser(request);
       if (!auth) {
         return NextResponse.json({ error: "Authentication required to use a deck" }, { status: 401 });
       }
       userId = auth.user.id;
+      firebaseUid = auth.session.uid;
     }
 
     let deckCardIds: string[] = [];
     if (userId && deckId) {
       deckCardIds = await resolveDeckCardIdsForUser(userId, deckId).catch(() => []);
     }
-    const state = await createMatch(trimmed, { deckId: deckId ?? undefined, userId, deckCardIds });
+    const state = await createMatch(trimmed, { deckId: deckId ?? undefined, userId, firebaseUid, deckCardIds });
 
     // p1Token is only sent here — it never appears in subsequent API responses.
     return NextResponse.json({ matchId: state.matchId, playerId: "p1", token: state.p1Token });

--- a/apps/web/app/api/match/join/route.ts
+++ b/apps/web/app/api/match/join/route.ts
@@ -19,19 +19,21 @@ export async function POST(request: NextRequest) {
 
     // When a deckId is provided, authenticate to verify deck ownership.
     let userId: string | undefined;
+    let firebaseUid: string | undefined;
     if (deckId) {
       const auth = await getAuthenticatedUser(request);
       if (!auth) {
         return NextResponse.json({ error: "Authentication required to use a deck" }, { status: 401 });
       }
       userId = auth.user.id;
+      firebaseUid = auth.session.uid;
     }
 
     let deckCardIds: string[] = [];
     if (userId && deckId) {
       deckCardIds = await resolveDeckCardIdsForUser(userId, deckId).catch(() => []);
     }
-    const state = await joinMatch(matchId.trim().toUpperCase(), trimmedName, { deckId: deckId ?? undefined, userId, deckCardIds });
+    const state = await joinMatch(matchId.trim().toUpperCase(), trimmedName, { deckId: deckId ?? undefined, userId, firebaseUid, deckCardIds });
     const token = state.p2Token!; // non-null: joinMatch() always assigns p2Token before returning
 
     return NextResponse.json({ matchId: state.matchId, playerId: "p2", token });

--- a/apps/web/app/match/match.module.css
+++ b/apps/web/app/match/match.module.css
@@ -200,8 +200,9 @@
 .joinButton,
 .secondaryButton {
     width: 100%;
+    min-height: 48px;
     border-radius: var(--radius-md);
-    font-size: var(--text-base);
+    font-size: var(--text-md);
     font-weight: 600;
     cursor: pointer;
     transition: opacity var(--ease-default), transform var(--ease-default), border-color var(--ease-default), background var(--ease-default);
@@ -214,19 +215,19 @@
 }
 
 .primaryButton {
-    padding: 0.8rem var(--space-xl);
+    padding: var(--space-md) var(--space-xl);
     background: linear-gradient(135deg, #9c7420, #d8ab4a);
 }
 
 .joinButton {
     width: auto;
     min-width: 120px;
-    padding: 0.8rem 1.25rem;
+    padding: var(--space-md) var(--space-lg);
     background: linear-gradient(135deg, #2c7a56, #4fb67b);
 }
 
 .secondaryButton {
-    padding: 0.8rem var(--space-xl);
+    padding: var(--space-md) var(--space-xl);
     border: 1px solid var(--color-border);
     background: rgba(17, 8, 4, 0.5);
     color: var(--color-text);

--- a/apps/web/lib/game-server/effect-resolver.ts
+++ b/apps/web/lib/game-server/effect-resolver.ts
@@ -24,6 +24,7 @@ import type {
 import type { TriggeredEffect } from "./event-bus";
 import { GameEvent, GameEventType, EventCause } from "./events";
 import { GAME, SPELL_COST_BY_RARITY } from "./constants";
+import { makeEventId, getOpponent, getCharacterEntityId } from "./utils";
 import {
   CardType,
   DamageType,
@@ -35,25 +36,6 @@ import {
 // ---------------------------------------------------------------------------
 // Local helpers
 // ---------------------------------------------------------------------------
-
-function makeEventId(): string {
-  return crypto.randomUUID();
-}
-
-/**
- * In the current player-centric model, a player's "character entity" is just
- * represented by a synthetic entity id.
- *
- * Later, when real entities/summons are added to MatchState, this should be
- * replaced by actual entity lookup.
- */
-function getCharacterEntityId(playerId: PlayerId): EntityId {
-  return `${playerId}:character`;
-}
-
-function getOpponent(playerId: PlayerId): PlayerId {
-  return playerId === "p1" ? "p2" : "p1";
-}
 
 function getPlayerEntities(state: MatchState, playerId: PlayerId): EntityId[] {
   return [

--- a/apps/web/lib/game-server/match.ts
+++ b/apps/web/lib/game-server/match.ts
@@ -5,14 +5,16 @@ import {
   PlayerState,
   PlayerId,
   ActionType,
-  EntityId,
+  CardConstraintState,
 } from "./types";
 import redis from "@/lib/redis";
 import prisma from "@/lib/prisma";
 import { GAME } from "./constants";
+import { makeEventId, getOpponent, getCharacterEntityId } from "./utils";
 
 interface MatchPlayerOptions {
   userId?: string | null;
+  firebaseUid?: string | null;
   deckId?: string;
   deckCardIds?: string[];
 }
@@ -100,17 +102,6 @@ function generateToken(): string {
   return crypto.randomBytes(32).toString("hex");
 }
 
-function makeEventId(): string {
-  return crypto.randomUUID();
-}
-
-function getOpponent(playerId: PlayerId): PlayerId {
-  return playerId === "p1" ? "p2" : "p1";
-}
-
-function getCharacterEntityId(playerId: PlayerId): EntityId {
-  return `${playerId}:character`;
-}
 
 function defaultPlayerState(name: string): PlayerState {
   return {
@@ -131,6 +122,7 @@ function defaultPlayerState(name: string): PlayerState {
     statusEffects: [],
     toolUsedThisTurn: false,
     turnRestriction: "none",
+    cardConstraints: {},
   };
 }
 
@@ -197,6 +189,14 @@ export async function loadDeckIntoPlayerState(
     [remaining[i], remaining[j]] = [remaining[j], remaining[i]];
   }
 
+  const cardConstraints: Record<string, CardConstraintState> = {};
+  for (const card of matchCards) {
+    const charges = card.effectJson.charges as number | undefined;
+    if (charges !== undefined) {
+      cardConstraints[card.instanceId] = { chargesRemaining: charges };
+    }
+  }
+
   return {
     name: playerName,
     hp: maxHp,
@@ -215,6 +215,7 @@ export async function loadDeckIntoPlayerState(
     statusEffects: [],
     toolUsedThisTurn: false,
     turnRestriction: "none",
+    cardConstraints,
   };
 }
 
@@ -246,7 +247,16 @@ function calculateUpdatedMmr(playerMmr: number, opponentMmr: number, didWin: boo
 }
 
 async function saveMatchState(state: MatchState) {
-  await redis.set(`match:${state.matchId}`, JSON.stringify(state), "EX", MATCH_TTL_SECONDS);
+  const expiresAt = new Date(Date.now() + MATCH_TTL_SECONDS * 1000);
+  await Promise.all([
+    redis.set(`match:${state.matchId}`, JSON.stringify(state), "EX", MATCH_TTL_SECONDS),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (prisma as any).match.upsert({
+      where: { id: state.matchId },
+      create: { id: state.matchId, state: state as object, expiresAt },
+      update: { state: state as object, expiresAt },
+    }),
+  ]);
 }
 
 async function publishMatchState(state: MatchState) {
@@ -360,6 +370,8 @@ export async function createMatch(
     p2Token: null,
     p1UserId: options.userId ?? null,
     p2UserId: null,
+    p1FirebaseUid: options.firebaseUid ?? null,
+    p2FirebaseUid: null,
     p1DeckCardIds: options.deckCardIds ?? [],
     p2DeckCardIds: [],
     p1DeckId: options.deckId ?? null,
@@ -371,8 +383,17 @@ export async function createMatch(
 }
 
 export async function getMatch(matchId: string): Promise<MatchState | null> {
-  const data = await redis.get(`match:${matchId}`);
-  return data ? JSON.parse(data) : null;
+  const cached = await redis.get(`match:${matchId}`);
+  if (cached) return JSON.parse(cached) as MatchState;
+
+  // Redis miss — try Postgres fallback (crash recovery)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row = await (prisma as any).match.findUnique({ where: { id: matchId } }) as { state: unknown; expiresAt: Date } | null;
+  if (!row || row.expiresAt < new Date()) return null;
+
+  const state = row.state as MatchState;
+  await redis.set(`match:${matchId}`, JSON.stringify(state), "EX", MATCH_TTL_SECONDS);
+  return state;
 }
 
 export async function joinMatch(
@@ -393,6 +414,7 @@ export async function joinMatch(
     state.status = "active";
     state.p2Token = generateToken();
     state.p2UserId = options.userId ?? null;
+    state.p2FirebaseUid = options.firebaseUid ?? null;
     state.p2DeckCardIds = options.deckCardIds ?? [];
     state.p2DeckId = options.deckId ?? null;
     state.log.push({ message: `${guestName} joined! ${state.players.p1.name}'s turn.` });
@@ -513,6 +535,10 @@ async function recordFinishedMatchStats(state: MatchState) {
   if (tasks.length > 0) {
     await Promise.all(tasks);
   }
+
+  // Clean up persisted match state now that stats are recorded
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (prisma as any).match.delete({ where: { id: state.matchId } }).catch(() => {});
 }
 
 export async function queueForMatchmaking(
@@ -635,6 +661,26 @@ function drawMatchingCard(
   return card ?? null;
 }
 
+function checkCardConstraints(card: MatchCard, player: PlayerState): void {
+  const c = player.cardConstraints[card.instanceId];
+  if (!c) return;
+  if (c.usedThisTurn) throw new Error(`${card.name} can only be used once per turn`);
+  if (c.cooldownRemaining && c.cooldownRemaining > 0)
+    throw new Error(`${card.name} is on cooldown for ${c.cooldownRemaining} more turn(s)`);
+  if (c.chargesRemaining !== undefined && c.chargesRemaining <= 0)
+    throw new Error(`${card.name} has no charges remaining`);
+}
+
+function consumeCardUse(card: MatchCard, player: PlayerState): void {
+  const oncePer = card.effectJson.oncePer as string | undefined;
+  const cooldown = card.effectJson.cooldown as number | undefined;
+  const c = player.cardConstraints[card.instanceId] ?? {};
+  if (oncePer === "turn") c.usedThisTurn = true;
+  if (cooldown !== undefined) c.cooldownRemaining = cooldown;
+  if (c.chargesRemaining !== undefined) c.chargesRemaining -= 1;
+  player.cardConstraints[card.instanceId] = c;
+}
+
 function isActionAllowedByRestriction(
   action: ActionType,
   restriction: PlayerState["turnRestriction"]
@@ -751,6 +797,11 @@ export async function applyAction(
         state.turnNumber += 1;
         attacker.toolUsedThisTurn = false;
         attacker.turnRestriction = "none";
+        for (const key of Object.keys(attacker.cardConstraints)) {
+          const c = attacker.cardConstraints[key]!;
+          c.usedThisTurn = false;
+          if (c.cooldownRemaining && c.cooldownRemaining > 0) c.cooldownRemaining -= 1;
+        }
 
         await redis.set(`match:${matchId}`, JSON.stringify(state), "EX", 900);
         await redis.publish(`match:${matchId}`, JSON.stringify(state));
@@ -927,10 +978,13 @@ export async function applyAction(
         if (spellIdx === -1) throw new Error("Spell not found in hand");
 
         const spell = attacker.hand[spellIdx]!;
+        checkCardConstraints(spell, attacker);
+
         const cost = getSpellCost(spell);
         if (attacker.energy < cost) throw new Error("Not enough energy");
 
         attacker.energy -= cost;
+        consumeCardUse(spell, attacker);
 
         state.log.push({
           message: `${attacker.name} cast ${spell.name} (${cost} energy)`,
@@ -963,7 +1017,10 @@ export async function applyAction(
         );
         if (!tool) throw new Error("Tool not found in equipped tools");
 
+        checkCardConstraints(tool, attacker);
+
         attacker.toolUsedThisTurn = true;
+        consumeCardUse(tool, attacker);
 
         state.log.push({
           message: `${attacker.name} used ${tool.name}`,
@@ -1075,6 +1132,11 @@ export async function applyAction(
       state.turnNumber += 1;
       attacker.toolUsedThisTurn = false;
       attacker.turnRestriction = "none";
+      for (const key of Object.keys(attacker.cardConstraints)) {
+        const c = attacker.cardConstraints[key]!;
+        c.usedThisTurn = false;
+        if (c.cooldownRemaining && c.cooldownRemaining > 0) c.cooldownRemaining -= 1;
+      }
       target.energy = target.maxEnergy;
     }
 

--- a/apps/web/lib/game-server/types.ts
+++ b/apps/web/lib/game-server/types.ts
@@ -160,6 +160,18 @@ export interface PlayerState {
 
   /** Action restriction from FREEZE/STUN */
   turnRestriction: "none" | "block_only" | "basic_only";
+
+  /** Per-card constraint state (once-per-turn, cooldowns, charges) keyed by instanceId */
+  cardConstraints: Record<CardInstanceId, CardConstraintState>;
+}
+
+export interface CardConstraintState {
+  /** True if this card has already been used this turn (once-per-turn cards) */
+  usedThisTurn?: boolean;
+  /** Turns remaining before the card can be used again; 0 means ready */
+  cooldownRemaining?: number;
+  /** Total uses remaining; undefined means unlimited */
+  chargesRemaining?: number;
 }
 
 /**
@@ -217,6 +229,8 @@ export interface MatchState {
   p2Token: string | null;
   p1UserId: string | null;
   p2UserId: string | null;
+  p1FirebaseUid: string | null;
+  p2FirebaseUid: string | null;
   p1DeckCardIds: string[];
   p2DeckCardIds: string[];
   p1DeckId: string | null;
@@ -226,10 +240,10 @@ export interface MatchState {
 // MatchState with private auth/identity/loadout fields removed. Safe to send to clients.
 export type PublicMatchState = Omit<
   MatchState,
-  "p1Token" | "p2Token" | "p1UserId" | "p2UserId" | "p1DeckCardIds" | "p2DeckCardIds" | "p1DeckId" | "p2DeckId"
+  "p1Token" | "p2Token" | "p1UserId" | "p2UserId" | "p1FirebaseUid" | "p2FirebaseUid" | "p1DeckCardIds" | "p2DeckCardIds" | "p1DeckId" | "p2DeckId"
 >;
 
 export function toPublicState(match: MatchState): PublicMatchState {
-  const { p1Token, p2Token, p1UserId, p2UserId, p1DeckCardIds, p2DeckCardIds, p1DeckId, p2DeckId, ...pub } = match;
+  const { p1Token, p2Token, p1UserId, p2UserId, p1FirebaseUid, p2FirebaseUid, p1DeckCardIds, p2DeckCardIds, p1DeckId, p2DeckId, ...pub } = match;
   return pub;
 }

--- a/apps/web/lib/game-server/utils.ts
+++ b/apps/web/lib/game-server/utils.ts
@@ -1,0 +1,14 @@
+import crypto from "crypto";
+import type { PlayerId, EntityId } from "./types";
+
+export function makeEventId(): string {
+  return crypto.randomUUID();
+}
+
+export function getOpponent(playerId: PlayerId): PlayerId {
+  return playerId === "p1" ? "p2" : "p1";
+}
+
+export function getCharacterEntityId(playerId: PlayerId): EntityId {
+  return `${playerId}:character`;
+}

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -86,6 +86,14 @@ model CardDefinition {
   cards       Card[]
 }
 
+model Match {
+  id        String   @id
+  state     Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  expiresAt DateTime
+}
+
 model Deck {
   id        String     @id @default(cuid())
   name      String

--- a/apps/web/test-scripts/mock-firebase-admin.ts
+++ b/apps/web/test-scripts/mock-firebase-admin.ts
@@ -1,0 +1,39 @@
+// In-memory stub of @/lib/firebase-admin for the test runner.
+// Returns a fake admin object whose verifyIdToken / verifySessionCookie just
+// pass through the supplied token as the uid. That lets route tests exercise
+// the auth-rejection branches without booting a real Firebase admin SDK.
+
+interface FakeDecodedToken {
+  uid: string;
+  [key: string]: unknown;
+}
+
+interface FakeAdminAuth {
+  verifyIdToken(token: string): Promise<FakeDecodedToken>;
+  verifySessionCookie(cookie: string, _checkRevoked?: boolean): Promise<FakeDecodedToken>;
+}
+
+// Tokens beginning with "uid-" are treated as valid; anything else throws.
+// This mirrors the structure of test fixtures used elsewhere ("uid-alice", etc).
+const fakeAdmin: FakeAdminAuth = {
+  async verifyIdToken(token: string) {
+    if (!token || !token.startsWith("uid-")) {
+      throw new Error("invalid id-token (mock)");
+    }
+    return { uid: token };
+  },
+  async verifySessionCookie(cookie: string) {
+    if (!cookie || !cookie.startsWith("uid-")) {
+      throw new Error("invalid session cookie (mock)");
+    }
+    return { uid: cookie };
+  },
+};
+
+export function getAdminAuth(): FakeAdminAuth {
+  return fakeAdmin;
+}
+
+export function getFirebaseAdmin(): unknown {
+  return {};
+}


### PR DESCRIPTION
… #88 #98

  - Extract makeEventId/getOpponent/getCharacterEntityId into game-server/utils.ts; both match.ts and effect-resolver.ts now import from there

  - #27: Store p1FirebaseUid/p2FirebaseUid on MatchState; action route cross-validates Firebase session against stored UID when player slot is authenticated — mismatches return 403, guest players unaffected

  - #88: Add CardConstraintState + cardConstraints to PlayerState; checkCardConstraints and consumeCardUse enforce once-per-turn, cooldowns, and charges on PLAY_SPELL and USE_TOOL; constraints reset/tick down at turn end

  - #38: Add Match model to schema.prisma; saveMatchState upserts to Postgres alongside Redis; getMatch falls back to Postgres on Redis miss for crash recovery; finished matches cleaned up from DB after stats are recorded (run migration: see MIGRATION_STEPS.txt)

  - #98: Match lobby buttons bumped to min-height 48px, var(--text-md), var(--space-md) padding for consistency with rest of app